### PR TITLE
feat: add Kyros Red cost calculator MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+.DS_Store
+.env.local
+.env
+npm-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# paanpt
+# Kyros Red F&B Cost Calculator MVP
+
+A Next.js prototype that showcases a GitHub-backed food & beverage costing workflow. The MVP loads fixture data, lets you model menu ingredient costs, and persists menu JSON files through the GitHub REST API.
+
+## Features
+
+- ✅ Reactive ingredient cost table with summary metrics
+- ✅ GitHub storage helpers for reading/writing repo content
+- ✅ Exporters for PDF (Kyros Red styling) and Excel workbooks
+- ✅ Sample chart visualising ingredient pricing trends
+- ✅ REST API route to persist menu drafts back to `menus/`
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Set the following environment variables for GitHub access:
+
+- `GITHUB_TOKEN`
+- `GITHUB_OWNER`
+- `GITHUB_REPO`
+
+Run the app and open http://localhost:3000.
+
+## Repository Data Shape
+
+This repository includes sample JSON, CSV, and Markdown files that illustrate how menu, supplier, SOP, and benchmarking data will be versioned in GitHub.

--- a/benchmarking/2025-10-01.json
+++ b/benchmarking/2025-10-01.json
@@ -1,0 +1,4 @@
+[
+  { "restaurant": "Brand A", "city": "KL", "item": "Kebab", "price": 13.5, "platform": "Foodpanda", "seen_at": "2025-10-01T10:05:00+08:00", "source": "https://example.com/a" },
+  { "restaurant": "Brand B", "city": "PJ", "item": "Kebab", "price": 14.9, "platform": "GrabFood", "seen_at": "2025-10-01T10:10:00+08:00", "source": "https://example.com/b" }
+]

--- a/components/CostTable.tsx
+++ b/components/CostTable.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from 'react';
+import ingredientsFixture from '@/data/ingredients.json';
+import type { CostRow, CostSummary, Ingredient } from '@/lib/types';
+
+type CostRowEditable = CostRow;
+
+const defaultIngredients: Ingredient[] = ingredientsFixture as Ingredient[];
+
+const initialRows: CostRowEditable[] = defaultIngredients.slice(0, 3).map((ingredient) => ({
+  ingredient_id: ingredient.id,
+  ingredientName: ingredient.name,
+  unit: ingredient.base_unit,
+  cost_per_unit: ingredient.approved_price?.unit_cost ?? 0,
+  quantity: ingredient.id === 'ing_beef' ? 120 : ingredient.id === 'ing_sauce_base' ? 40 : 1,
+  totalCost:
+    (ingredient.approved_price?.unit_cost ?? 0) *
+    (ingredient.id === 'ing_beef' ? 120 : ingredient.id === 'ing_sauce_base' ? 40 : 1)
+}));
+
+const calculateSummary = (rows: CostRowEditable[], sellingPrice: number, miscPct: number): CostSummary => {
+  const subtotal = rows.reduce((acc, row) => acc + row.totalCost, 0);
+  const miscAmount = subtotal * miscPct;
+  const totalCost = subtotal + miscAmount;
+  const costPercentage = sellingPrice > 0 ? (totalCost / sellingPrice) * 100 : 0;
+
+  return {
+    subtotal,
+    miscAmount,
+    totalCost,
+    sellingPrice,
+    costPercentage
+  };
+};
+
+export interface CostTableProps {
+  sellingPrice: number;
+  miscPct: number;
+  onChange?: (rows: CostRowEditable[], summary: CostSummary) => void;
+}
+
+export const CostTable = ({ sellingPrice, miscPct, onChange }: CostTableProps) => {
+  const [rows, setRows] = useState<CostRowEditable[]>(initialRows);
+
+  const summary = useMemo(() => calculateSummary(rows, sellingPrice, miscPct), [rows, sellingPrice, miscPct]);
+
+  useEffect(() => {
+    onChange?.(rows, summary);
+  }, [rows, summary, onChange]);
+
+  const updateRow = (index: number, updates: Partial<CostRowEditable>) => {
+    setRows((prev) => {
+      const updated = prev.map((row, i) =>
+        i === index
+          ? {
+              ...row,
+              ...updates,
+              totalCost: ((updates.cost_per_unit ?? row.cost_per_unit) * (updates.quantity ?? row.quantity)) || 0
+            }
+          : row
+      );
+      return updated;
+    });
+  };
+
+  const handleIngredientSelect = (index: number, ingredientId: string) => {
+    const ingredient = defaultIngredients.find((item) => item.id === ingredientId);
+    if (!ingredient) return;
+
+    updateRow(index, {
+      ingredient_id: ingredient.id,
+      ingredientName: ingredient.name,
+      unit: ingredient.base_unit,
+      cost_per_unit: ingredient.approved_price?.unit_cost ?? 0,
+      quantity: 1
+    });
+  };
+
+  const addRow = () => {
+    const ingredient = defaultIngredients[0];
+    setRows((prev) => [
+      ...prev,
+      {
+        ingredient_id: ingredient?.id ?? `pending_${prev.length + 1}`,
+        ingredientName: ingredient?.name ?? 'New Ingredient',
+        unit: ingredient?.base_unit ?? 'unit',
+        cost_per_unit: ingredient?.approved_price?.unit_cost ?? 0,
+        quantity: 1,
+        totalCost: ingredient?.approved_price?.unit_cost ?? 0
+      }
+    ]);
+  };
+
+  const removeRow = (index: number) => {
+    setRows((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">F&amp;B Cost Table</h2>
+        <button type="button" className="btn-secondary" onClick={addRow}>
+          Add Ingredient
+        </button>
+      </div>
+
+      <div className="mt-4 overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-100 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">
+            <tr>
+              <th className="px-4 py-3">Item</th>
+              <th className="px-4 py-3">Unit</th>
+              <th className="px-4 py-3">Cost / Unit (RM)</th>
+              <th className="px-4 py-3">Quantity</th>
+              <th className="px-4 py-3">Total (RM)</th>
+              <th className="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 bg-white">
+            {rows.map((row, index) => (
+              <tr key={index} className="align-top">
+                <td className="px-4 py-3">
+                  <select
+                    value={row.ingredient_id}
+                    onChange={(event) => handleIngredientSelect(index, event.target.value)}
+                    className="mt-1 block w-full rounded-md border-slate-300 text-sm shadow-sm focus:border-kyros-red focus:ring-kyros-red"
+                  >
+                    {defaultIngredients.map((ingredient) => (
+                      <option key={ingredient.id} value={ingredient.id}>
+                        {ingredient.name}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-xs text-slate-500">SKU: {row.ingredient_id}</p>
+                </td>
+                <td className="px-4 py-3">
+                  <input
+                    type="text"
+                    value={row.unit}
+                    onChange={(event) => updateRow(index, { unit: event.target.value })}
+                    className="mt-1 block w-24 rounded-md border-slate-300 text-sm shadow-sm focus:border-kyros-red focus:ring-kyros-red"
+                  />
+                </td>
+                <td className="px-4 py-3">
+                  <input
+                    type="number"
+                    value={row.cost_per_unit}
+                    step="0.001"
+                    onChange={(event) => updateRow(index, { cost_per_unit: Number(event.target.value) })}
+                    className="mt-1 block w-32 rounded-md border-slate-300 text-sm shadow-sm focus:border-kyros-red focus:ring-kyros-red"
+                  />
+                </td>
+                <td className="px-4 py-3">
+                  <input
+                    type="number"
+                    value={row.quantity}
+                    step="0.1"
+                    onChange={(event) => updateRow(index, { quantity: Number(event.target.value) })}
+                    className="mt-1 block w-24 rounded-md border-slate-300 text-sm shadow-sm focus:border-kyros-red focus:ring-kyros-red"
+                  />
+                </td>
+                <td className="px-4 py-3 font-medium text-slate-900">RM {row.totalCost.toFixed(2)}</td>
+                <td className="px-4 py-3 text-right">
+                  <button
+                    type="button"
+                    className="text-sm font-medium text-red-500 hover:text-red-600"
+                    onClick={() => removeRow(index)}
+                    disabled={rows.length <= 1}
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-6 grid gap-3 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-slate-600">Total Ingredient Cost</span>
+          <span className="font-semibold">RM {summary.subtotal.toFixed(2)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-slate-600">Misc ({(miscPct * 100).toFixed(0)}%)</span>
+          <span className="font-semibold">RM {summary.miscAmount.toFixed(2)}</span>
+        </div>
+        <div className="flex items-center justify-between border-t border-dashed border-slate-200 pt-3 text-base font-semibold">
+          <span>Total Cost</span>
+          <span>RM {summary.totalCost.toFixed(2)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-slate-600">Selling Price</span>
+          <span className="font-semibold">RM {sellingPrice.toFixed(2)}</span>
+        </div>
+        <div className="flex items-center justify-between text-base">
+          <span className="font-semibold text-slate-700">Cost %</span>
+          <span className="font-semibold text-kyros-red">{summary.costPercentage.toFixed(1)}%</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CostTable;

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,7 @@
+[
+  { "id": "cat_protein", "name": "Protein", "parent_id": null },
+  { "id": "cat_protein_beef", "name": "Beef", "parent_id": "cat_protein" },
+  { "id": "cat_bakery", "name": "Bakery", "parent_id": null },
+  { "id": "cat_bakery_pita", "name": "Pita", "parent_id": "cat_bakery" },
+  { "id": "cat_sauce", "name": "Sauces", "parent_id": null }
+]

--- a/data/ingredients.json
+++ b/data/ingredients.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ing_pita",
+    "name": "Pita Bread",
+    "category_id": "cat_bakery_pita",
+    "base_unit": "pcs",
+    "sku": "PITA-001",
+    "approved_price": { "unit_cost": 0.8, "currency": "RM", "quoted_at": "2025-09-15", "supplier_id": "sup_bakery_a" }
+  },
+  {
+    "id": "ing_beef",
+    "name": "Beef Slice",
+    "category_id": "cat_protein_beef",
+    "base_unit": "g",
+    "sku": "BEEF-100",
+    "approved_price": { "unit_cost": 0.035, "currency": "RM", "quoted_at": "2025-09-22", "supplier_id": "sup_meat_a" }
+  },
+  {
+    "id": "ing_sauce_base",
+    "name": "Sauce Base",
+    "category_id": "cat_sauce",
+    "base_unit": "ml",
+    "sku": "SAUCE-BASE-01",
+    "approved_price": { "unit_cost": 0.01, "currency": "RM", "quoted_at": "2025-09-25", "supplier_id": "sup_condiments_a" }
+  }
+]

--- a/data/suppliers.json
+++ b/data/suppliers.json
@@ -1,0 +1,5 @@
+[
+  { "id": "sup_bakery_a", "name": "Sunrise Bakery", "contacts": { "phone": "+60 12-345 6789" } },
+  { "id": "sup_meat_a", "name": "Malay Meats", "contacts": { "phone": "+60 17-555 1212" } },
+  { "id": "sup_condiments_a", "name": "Condimix Sdn Bhd", "contacts": { "phone": "+60 19-222 3344" } }
+]

--- a/lib/export-excel.ts
+++ b/lib/export-excel.ts
@@ -1,0 +1,69 @@
+import type { CostRow, CostSummary } from './types';
+import * as XLSX from 'xlsx';
+
+export interface ExcelExportOptions {
+  title: string;
+  rows: CostRow[];
+  summary: CostSummary;
+}
+
+export function exportCostingExcel({ title, rows, summary }: ExcelExportOptions) {
+  const worksheetData: (string | number | XLSX.CellObject)[][] = [
+    ['Item', 'Unit', 'Cost/Unit (RM)', 'Quantity', 'Total (RM)'],
+    ...rows.map((row, index) => [
+      row.ingredientName,
+      row.unit,
+      row.cost_per_unit,
+      row.quantity,
+      { t: 'n', f: `C${index + 2}*D${index + 2}` }
+    ])
+  ];
+
+  const ws = XLSX.utils.aoa_to_sheet(worksheetData);
+  const lastRow = rows.length + 2;
+
+  XLSX.utils.sheet_add_aoa(
+    ws,
+    [
+      ['Subtotal', null, null, null, summary.subtotal],
+      ['Misc (10%)', null, null, null, summary.miscAmount],
+      ['Total Cost', null, null, null, summary.totalCost],
+      ['Selling Price', null, null, null, summary.sellingPrice],
+      ['Cost %', null, null, null, summary.costPercentage / 100]
+    ],
+    { origin: `A${lastRow}` }
+  );
+
+  const range = XLSX.utils.decode_range(ws['!ref'] || `A1:E${lastRow + 4}`);
+  for (let R = 1; R <= rows.length; R += 1) {
+    const cellAddress = XLSX.utils.encode_cell({ r: R, c: 4 });
+    const cell = ws[cellAddress];
+    if (cell && typeof cell === 'object') {
+      cell.z = '[$RM-421] #,##0.00';
+    }
+  }
+
+  ['E', 'A'].forEach((column) => {
+    for (let R = 1; R <= range.e.r; R += 1) {
+      const cell = ws[`${column}${R + 1}`];
+      if (cell && typeof cell === 'object') {
+        cell.z = column === 'E' ? '[$RM-421] #,##0.00' : undefined;
+      }
+    }
+  });
+
+  ws['!cols'] = [
+    { wch: 28 },
+    { wch: 10 },
+    { wch: 16 },
+    { wch: 12 },
+    { wch: 16 }
+  ];
+
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Costing');
+  const fileName = `fbcalc_costing_${title.replace(/\s+/g, '-').toLowerCase()}_${
+    new Date().toISOString().replace(/[-:]/g, '').slice(0, 15)
+  }.xlsx`;
+  XLSX.writeFile(wb, fileName);
+}

--- a/lib/export-pdf.ts
+++ b/lib/export-pdf.ts
@@ -1,0 +1,71 @@
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import type { CostRow, CostSummary } from './types';
+
+export interface PdfExportOptions {
+  title: string;
+  rows: CostRow[];
+  summary: CostSummary;
+}
+
+function formatCurrency(value: number) {
+  return `RM ${value.toFixed(2)}`;
+}
+
+export async function exportCostingPdf({ title, rows, summary }: PdfExportOptions) {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(18);
+  doc.setTextColor('#D91C1C');
+  doc.text(title, 40, 50);
+
+  doc.setFontSize(12);
+  doc.setTextColor('#000');
+  doc.text('Kyros Red F&B Cost Calculator', 40, 70);
+
+  autoTable(doc, {
+    head: [['Item', 'Unit', 'Cost/Unit (RM)', 'Qty', 'Total (RM)']],
+    body: rows.map((row) => [
+      row.ingredientName,
+      row.unit,
+      row.cost_per_unit.toFixed(2),
+      row.quantity.toString(),
+      row.totalCost.toFixed(2)
+    ]),
+    startY: 90,
+    theme: 'grid',
+    styles: {
+      halign: 'left'
+    },
+    headStyles: {
+      fillColor: [217, 28, 28],
+      textColor: 255
+    }
+  });
+
+  let y = (doc as any).lastAutoTable?.finalY ?? 120;
+  y += 30;
+
+  doc.setFont('helvetica', 'bold');
+  doc.text('Summary', 40, y);
+  doc.setFont('helvetica', 'normal');
+  y += 20;
+
+  const summaryEntries = [
+    ['Subtotal', formatCurrency(summary.subtotal)],
+    ['Misc (10%)', formatCurrency(summary.miscAmount)],
+    ['Total Cost', formatCurrency(summary.totalCost)],
+    ['Selling Price', formatCurrency(summary.sellingPrice)],
+    ['Cost %', `${summary.costPercentage.toFixed(1)}%`]
+  ];
+
+  summaryEntries.forEach(([label, value]) => {
+    doc.text(label, 40, y);
+    doc.text(value, pageWidth - 40 - doc.getTextWidth(value), y);
+    y += 18;
+  });
+
+  doc.save(`fbcalc_costing_${new Date().toISOString().slice(0, 10)}.pdf`);
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,67 @@
+import type { GitHubFileResponse, GitHubPutPayload, GitHubPutResponse } from './types';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+
+function getAuthHeaders() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is not set');
+  }
+
+  return {
+    Authorization: `token ${token}`,
+    'Content-Type': 'application/json'
+  };
+}
+
+function getRepoParams() {
+  const owner = process.env.GITHUB_OWNER;
+  const repo = process.env.GITHUB_REPO;
+
+  if (!owner || !repo) {
+    throw new Error('GITHUB_OWNER or GITHUB_REPO is not set');
+  }
+
+  return { owner, repo };
+}
+
+export async function getFile<T = unknown>(path: string): Promise<GitHubFileResponse<T>> {
+  const { owner, repo } = getRepoParams();
+  const response = await fetch(`${GITHUB_API_BASE}/repos/${owner}/${repo}/contents/${path}`, {
+    headers: getAuthHeaders(),
+    cache: 'no-store'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load ${path}: ${response.status} ${response.statusText}`);
+  }
+
+  const json = await response.json();
+  const content = JSON.parse(Buffer.from(json.content, 'base64').toString('utf-8')) as T;
+  return { content, sha: json.sha };
+}
+
+export async function putFile(path: string, payload: GitHubPutPayload): Promise<GitHubPutResponse> {
+  const { owner, repo } = getRepoParams();
+  const response = await fetch(`${GITHUB_API_BASE}/repos/${owner}/${repo}/contents/${path}`, {
+    method: 'PUT',
+    headers: getAuthHeaders(),
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to save ${path}: ${response.status} ${response.statusText} - ${message}`);
+  }
+
+  return (await response.json()) as GitHubPutResponse;
+}
+
+export function buildPutPayload<T>(data: T, message: string, sha?: string, branch?: string): GitHubPutPayload {
+  return {
+    message,
+    content: Buffer.from(JSON.stringify(data, null, 2)).toString('base64'),
+    ...(sha ? { sha } : {}),
+    ...(branch ? { branch } : {})
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,89 @@
+export interface SupplierQuote {
+  date: string;
+  supplier_id: string;
+  ingredient_id: string;
+  pack_size: number;
+  pack_unit: string;
+  pack_cost: number;
+  unit_cost: number;
+}
+
+export interface SupplierContact {
+  phone?: string;
+  email?: string;
+}
+
+export interface Supplier {
+  id: string;
+  name: string;
+  contacts?: SupplierContact;
+}
+
+export interface IngredientApprovedPrice {
+  unit_cost: number;
+  currency: string;
+  quoted_at: string;
+  supplier_id: string;
+}
+
+export interface Ingredient {
+  id: string;
+  name: string;
+  category_id: string;
+  base_unit: string;
+  sku: string;
+  approved_price?: IngredientApprovedPrice;
+}
+
+export interface MenuItemInput {
+  ingredient_id: string;
+  unit: string;
+  cost_per_unit: number;
+  quantity: number;
+}
+
+export interface MenuDraft {
+  id: string;
+  name: string;
+  selling_price: number;
+  misc_pct: number;
+  items: MenuItemInput[];
+}
+
+export interface GitHubFileResponse<T> {
+  content: T;
+  sha: string;
+}
+
+export interface GitHubPutPayload {
+  message: string;
+  content: string;
+  sha?: string;
+  branch?: string;
+}
+
+export interface GitHubPutResponse {
+  content: {
+    path: string;
+    sha: string;
+    html_url: string;
+  };
+  commit: {
+    sha: string;
+    message: string;
+    html_url: string;
+  };
+}
+
+export interface CostRow extends MenuItemInput {
+  ingredientName: string;
+  totalCost: number;
+}
+
+export interface CostSummary {
+  subtotal: number;
+  miscAmount: number;
+  totalCost: number;
+  sellingPrice: number;
+  costPercentage: number;
+}

--- a/menus/combos/lunch-combo-a.json
+++ b/menus/combos/lunch-combo-a.json
@@ -1,0 +1,9 @@
+{
+  "id": "combo_lunch_a",
+  "name": "Lunch Combo A",
+  "items": [
+    { "menu_id": "menu_kebab", "portion_multiplier": 1 },
+    { "menu_id": "menu_burger", "portion_multiplier": 1 }
+  ],
+  "status": "Draft"
+}

--- a/menus/kebab.json
+++ b/menus/kebab.json
@@ -1,0 +1,14 @@
+{
+  "id": "menu_kebab",
+  "name": "Kyros Kebab",
+  "yield_qty": 1,
+  "yield_unit": "serving",
+  "selling_price": 12.9,
+  "status": "Published",
+  "items": [
+    { "ingredient_id": "ing_pita", "unit": "pcs", "cost_per_unit": 0.8, "quantity": 1 },
+    { "ingredient_id": "ing_beef", "unit": "g", "cost_per_unit": 0.035, "quantity": 120 },
+    { "ingredient_id": "ing_sauce_base", "unit": "ml", "cost_per_unit": 0.01, "quantity": 40 }
+  ],
+  "misc_pct": 0.1
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+module.exports = nextConfig;

--- a/outlets/outlet-bangsar/menus.json
+++ b/outlets/outlet-bangsar/menus.json
@@ -1,0 +1,4 @@
+{
+  "menus": ["menu_kebab"],
+  "updated_at": "2025-09-25"
+}

--- a/outlets/outlet-bangsar/suppliers.json
+++ b/outlets/outlet-bangsar/suppliers.json
@@ -1,0 +1,4 @@
+{
+  "preferred": ["sup_bakery_a"],
+  "updated_at": "2025-09-21"
+}

--- a/outlets/outlet-klcc/menus.json
+++ b/outlets/outlet-klcc/menus.json
@@ -1,0 +1,4 @@
+{
+  "menus": ["menu_kebab", "menu_burger"],
+  "updated_at": "2025-09-30"
+}

--- a/outlets/outlet-klcc/suppliers.json
+++ b/outlets/outlet-klcc/suppliers.json
@@ -1,0 +1,4 @@
+{
+  "preferred": ["sup_bakery_a", "sup_meat_a"],
+  "updated_at": "2025-09-28"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "paanpt",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.8.2",
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.9.0",
+    "xlsx": "^0.18.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.56",
+    "@types/react-dom": "^18.2.19",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.2"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '@/styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/api/github/save-menu.ts
+++ b/pages/api/github/save-menu.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { buildPutPayload, getFile, putFile } from '@/lib/github';
+import type { MenuDraft } from '@/lib/types';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const menu = req.body as MenuDraft;
+  const path = req.query.path ? String(req.query.path) : `menus/${menu.id}.json`;
+
+  try {
+    let sha: string | undefined;
+    try {
+      const existing = await getFile(path);
+      sha = existing.sha;
+    } catch (error) {
+      sha = undefined;
+    }
+
+    const payload = buildPutPayload(menu, `feat(menus): update ${menu.id}`, sha);
+    const response = await putFile(path, payload);
+    return res.status(200).json(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return res.status(500).json({ error: message });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useMemo, useState } from 'react';
+import Head from 'next/head';
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import CostTable from '@/components/CostTable';
+import { exportCostingExcel } from '@/lib/export-excel';
+import { exportCostingPdf } from '@/lib/export-pdf';
+import type { CostRow, CostSummary, MenuDraft } from '@/lib/types';
+import ingredientsFixture from '@/data/ingredients.json';
+
+const lineData = [
+  { date: 'Sep 1', avg: 3.1 },
+  { date: 'Sep 8', avg: 3.3 },
+  { date: 'Sep 15', avg: 3.28 },
+  { date: 'Sep 22', avg: 3.25 },
+  { date: 'Sep 29', avg: 3.32 },
+  { date: 'Oct 6', avg: 3.35 }
+];
+
+export default function HomePage() {
+  const [sellingPrice, setSellingPrice] = useState<number>(12.9);
+  const [miscPct, setMiscPct] = useState<number>(0.1);
+  const [rows, setRows] = useState<CostRow[]>([]);
+  const [summary, setSummary] = useState<CostSummary | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleTableChange = useCallback((updatedRows: CostRow[], updatedSummary: CostSummary) => {
+    setRows(updatedRows);
+    setSummary(updatedSummary);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!summary) return;
+
+    setSaving(true);
+    setMessage(null);
+    const menuDraft: MenuDraft = {
+      id: 'menu_kebab',
+      name: 'Kyros Kebab',
+      selling_price: summary.sellingPrice,
+      misc_pct: miscPct,
+      items: rows.map((row) => ({
+        ingredient_id: row.ingredient_id,
+        unit: row.unit,
+        cost_per_unit: row.cost_per_unit,
+        quantity: row.quantity
+      }))
+    };
+
+    try {
+      const response = await fetch('/api/github/save-menu', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(menuDraft)
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error ?? 'Failed to save menu');
+      }
+
+      setMessage('Menu saved to GitHub successfully.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Failed to save menu');
+    } finally {
+      setSaving(false);
+    }
+  }, [miscPct, rows, summary]);
+
+  const handleExportPdf = useCallback(() => {
+    if (!summary) return;
+    exportCostingPdf({
+      title: 'Kyros Kebab Costing',
+      rows,
+      summary
+    });
+  }, [rows, summary]);
+
+  const handleExportExcel = useCallback(() => {
+    if (!summary) return;
+    exportCostingExcel({
+      title: 'Kyros Kebab',
+      rows,
+      summary
+    });
+  }, [rows, summary]);
+
+  const averageCost = useMemo(() => {
+    const ingredientWithAvg = ingredientsFixture.find((item) => item.id === 'ing_beef');
+    return ingredientWithAvg?.approved_price?.unit_cost ?? 0;
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>Kyros Red F&amp;B Cost Calculator</title>
+      </Head>
+
+      <main className="mx-auto max-w-6xl gap-6 px-6 py-10 lg:flex">
+        <section className="lg:w-2/3">
+          <div className="mb-4 flex flex-wrap items-center gap-4">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-900">F&amp;B Cost Calculator</h1>
+              <p className="text-sm text-slate-600">Build menu costings, combos, and SOP-ready data with Kyros Red.</p>
+            </div>
+            <span className="rounded-full bg-kyros-red/10 px-3 py-1 text-sm font-medium text-kyros-red">
+              RM Currency • GitHub Storage
+            </span>
+          </div>
+
+          <div className="card mb-6 p-4">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <label className="text-sm">
+                <span className="text-slate-600">Selling Price (RM)</span>
+                <input
+                  type="number"
+                  value={sellingPrice}
+                  step="0.1"
+                  onChange={(event) => setSellingPrice(Number(event.target.value))}
+                  className="mt-1 block w-full rounded-md border-slate-300 text-sm shadow-sm focus:border-kyros-red focus:ring-kyros-red"
+                />
+              </label>
+              <label className="text-sm">
+                <span className="text-slate-600">Misc Percentage</span>
+                <input
+                  type="number"
+                  value={miscPct * 100}
+                  step="1"
+                  onChange={(event) => setMiscPct(Number(event.target.value) / 100)}
+                  className="mt-1 block w-full rounded-md border-slate-300 text-sm shadow-sm focus:border-kyros-red focus:ring-kyros-red"
+                />
+              </label>
+              <div className="flex items-end">
+                <button type="button" className="btn-secondary w-full">Create Combo Menu</button>
+              </div>
+            </div>
+          </div>
+
+          <CostTable sellingPrice={sellingPrice} miscPct={miscPct} onChange={handleTableChange} />
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <button type="button" className="btn-primary" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving...' : 'Save to GitHub'}
+            </button>
+            <button type="button" className="btn-secondary" onClick={handleExportPdf}>
+              Export PDF
+            </button>
+            <button type="button" className="btn-secondary" onClick={handleExportExcel}>
+              Export Excel
+            </button>
+          </div>
+
+          {message && <p className="mt-4 text-sm text-slate-600">{message}</p>}
+        </section>
+
+        <aside className="mt-10 space-y-6 lg:mt-0 lg:w-1/3">
+          <div className="card space-y-4 p-6">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">Ingredient Price Trend</h2>
+              <p className="text-sm text-slate-500">30-day average for Beef Slice</p>
+            </div>
+            <div className="h-52 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={lineData}>
+                  <XAxis dataKey="date" stroke="#94a3b8" fontSize={12} tickLine={false} axisLine={false} />
+                  <YAxis stroke="#94a3b8" fontSize={12} tickFormatter={(value) => `RM ${value.toFixed(2)}`} width={80} />
+                  <Tooltip formatter={(value: number) => `RM ${value.toFixed(2)}`} labelStyle={{ color: '#0f172a' }} />
+                  <Line type="monotone" dataKey="avg" stroke="#D91C1C" strokeWidth={3} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="flex items-center justify-between rounded-lg bg-kyros-red/10 px-4 py-3 text-sm">
+              <span className="font-medium text-kyros-red">30-Day Avg</span>
+              <span className="font-semibold text-slate-900">RM {averageCost.toFixed(3)}</span>
+            </div>
+          </div>
+
+          <div className="card space-y-3 p-6 text-sm text-slate-600">
+            <h3 className="text-base font-semibold text-slate-900">What&apos;s Next</h3>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>Auto-generate SOP cards and QR-ready outlet mode.</li>
+              <li>Supplier quote intake with OCR to append CSV history.</li>
+              <li>Benchmark pricing snapshots per outlet and platform.</li>
+              <li>GitHub PR approvals to manage role-based access.</li>
+            </ul>
+          </div>
+        </aside>
+      </main>
+    </>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/sops/kebab.md
+++ b/sops/kebab.md
@@ -1,0 +1,14 @@
+# SOP: Kyros Kebab
+**Yield:** 1 serving  
+**Allergens:** Gluten
+
+## Steps
+1. **Grill (180s):** Sear beef slices on medium heat.  
+2. **Warm Pita (30s):** Steam or toast lightly.  
+3. **Assemble (60s):** Add beef, sauce, and salad.
+
+## Checklist (Opening)
+- [ ] Check grill temperature  
+- [ ] Refill sauce bottles
+
+*Version:* 2025-09-30 • *Acknowledgement:* Required

--- a/sops/sauces.yaml
+++ b/sops/sauces.yaml
@@ -1,0 +1,17 @@
+name: Sauce Base SOP
+yield: 2 liters
+steps:
+  - step_no: 1
+    station: Cold
+    timer_sec: 180
+    instruction: Mix dry spices.
+  - step_no: 2
+    station: Cold
+    timer_sec: 600
+    instruction: Whisk with liquids until smooth.
+checklists:
+  - title: Closing
+    frequency: daily
+    items:
+      - Clean station
+      - Chill remaining sauce

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,28 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --brand-primary: #d91c1c;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.brand-primary {
+  color: var(--brand-primary);
+}
+
+.btn-primary {
+  @apply inline-flex items-center justify-center rounded-md bg-kyros-red px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kyros-red;
+}
+
+.btn-secondary {
+  @apply inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-4 py-2 font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kyros-red;
+}
+
+.card {
+  @apply rounded-xl border border-slate-200 bg-white shadow-sm;
+}

--- a/suppliers/quotes/2025-10-01.csv
+++ b/suppliers/quotes/2025-10-01.csv
@@ -1,0 +1,4 @@
+date,supplier_id,ingredient_id,pack_size,pack_unit,pack_cost,unit_cost
+2025-10-01,sup_meat_a,ing_beef,10,kg,320,0.032
+2025-10-01,sup_bakery_a,ing_pita,100,pcs,75,0.75
+2025-10-01,sup_condiments_a,ing_sauce_base,5,l,60,0.012

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,18 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./app/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        kyros: {
+          red: "#D91C1C"
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/jspdf-autotable.d.ts
+++ b/types/jspdf-autotable.d.ts
@@ -1,0 +1,1 @@
+declare module 'jspdf-autotable';


### PR DESCRIPTION
## Summary
- scaffold a Next.js + Tailwind UI for the Kyros Red F&B cost calculator with GitHub-backed persistence
- add reusable GitHub content helpers plus PDF and Excel exporters wired to the MVP costing screen
- seed the repository with sample data for ingredients, menus, SOPs, suppliers, benchmarking, and outlets

## Testing
- npm install *(fails: registry access is restricted in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dcabb35340832081baca324bb1ec54