### PR TITLE
feat: convert project into WordPress cost calculator plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+.DS_Store
+.env.local
+.env
+npm-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# paanpt
+# Kyros F&B Cost Calculator WordPress Plugin
+
+This repository contains a WordPress plugin that delivers the Kyros F&B cost calculator as an admin experience. The plugin consumes menu and ingredient files stored in GitHub, allows authorised users to edit menu costings, and exports the results to PDF or Excel from inside WordPress.
+
+## Features
+- **GitHub-backed storage**: read and write JSON/CSV/Markdown files in a GitHub repository via the REST API (requires a personal access token).
+- **Menu cost calculator**: interactive table with RM currency totals, miscellaneous percentages, and selling price comparisons.
+- **PDF & Excel exports**: generate Kyros-branded PDF reports (via jsPDF) and Excel workbooks (via SheetJS) directly in the browser.
+- **WordPress-native settings**: configure GitHub credentials and default menu paths from the admin Settings page.
+- **Plugin-ready bundle**: the repository structure maps 1:1 to a WordPress plugin folder so it can be zipped and uploaded through the WordPress dashboard.
+
+## Getting Started
+1. Zip the project contents (for example `zip -r kyros-fnb-cost-calculator.zip .`).
+2. Upload the archive through **WordPress Admin → Plugins → Add New → Upload Plugin**.
+3. Activate the **Kyros F&B Cost Calculator** plugin.
+4. Visit **Settings → Kyros F&B Cost Calculator** to enter your GitHub Personal Access Token, owner, repository, and default menu path.
+5. Open **Kyros F&B → Cost Calculator** from the admin sidebar to load and edit your menu.
+
+## Development Notes
+- The plugin registers REST endpoints under `/wp-json/kyros-fnb/v1/` which proxy GitHub content requests using the saved credentials.
+- JavaScript assets are written in vanilla ES modules and enqueue jsPDF and SheetJS from trusted CDNs.
+- PDF exports are formatted for A4 portrait with Kyros Red branding (#D91C1C).
+
+## Requirements
+- WordPress 6.0+
+- PHP 8.0+
+- GitHub Personal Access Token with `repo` scope for private repositories (or read/write permissions for public repos).
+
+## License
+MIT

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,84 @@
+.kyros-fnb-admin {
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.05);
+  border-top: 5px solid #d91c1c;
+}
+
+.kyros-fnb-admin .kyros-fnb-toolbar {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.kyros-fnb-admin table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 24px;
+}
+
+.kyros-fnb-admin table thead {
+  background: #f9f3f3;
+  color: #611010;
+}
+
+.kyros-fnb-admin table th,
+.kyros-fnb-admin table td {
+  border: 1px solid #e2e8f0;
+  padding: 10px;
+  text-align: left;
+}
+
+.kyros-fnb-admin input[type="text"],
+.kyros-fnb-admin input[type="number"],
+.kyros-fnb-admin select {
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid #cbd5e1;
+}
+
+.kyros-fnb-admin .kyros-fnb-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.kyros-fnb-admin .kyros-fnb-card {
+  background: #fff5f5;
+  border: 1px solid #fdd5d5;
+  border-radius: 6px;
+  padding: 16px;
+}
+
+.kyros-fnb-admin .kyros-fnb-card h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.kyros-fnb-admin .button-primary,
+.kyros-fnb-admin .kyros-fnb-button-primary {
+  background: #d91c1c;
+  border-color: #b81717;
+  text-shadow: none;
+  box-shadow: none;
+}
+
+.kyros-fnb-admin .button-primary:hover,
+.kyros-fnb-admin .kyros-fnb-button-primary:hover {
+  background: #b81717;
+}
+
+.kyros-fnb-admin .kyros-fnb-chart {
+  min-height: 260px;
+  border: 1px dashed #fbb6b6;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #c53030;
+  background: #fffaf7;
+}

--- a/assets/data/categories.json
+++ b/assets/data/categories.json
@@ -1,0 +1,7 @@
+[
+  { "id": "cat_protein", "name": "Protein", "parent_id": null },
+  { "id": "cat_protein_beef", "name": "Beef", "parent_id": "cat_protein" },
+  { "id": "cat_bakery", "name": "Bakery", "parent_id": null },
+  { "id": "cat_bakery_pita", "name": "Pita", "parent_id": "cat_bakery" },
+  { "id": "cat_sauce", "name": "Sauces", "parent_id": null }
+]

--- a/assets/data/ingredients.json
+++ b/assets/data/ingredients.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ing_pita",
+    "name": "Pita Bread",
+    "category_id": "cat_bakery_pita",
+    "base_unit": "pcs",
+    "sku": "PITA-001",
+    "approved_price": { "unit_cost": 0.8, "currency": "RM", "quoted_at": "2025-09-15", "supplier_id": "sup_bakery_a" }
+  },
+  {
+    "id": "ing_beef",
+    "name": "Beef Slice",
+    "category_id": "cat_protein_beef",
+    "base_unit": "g",
+    "sku": "BEEF-100",
+    "approved_price": { "unit_cost": 0.035, "currency": "RM", "quoted_at": "2025-09-22", "supplier_id": "sup_meat_a" }
+  },
+  {
+    "id": "ing_sauce_base",
+    "name": "Sauce Base",
+    "category_id": "cat_sauce",
+    "base_unit": "ml",
+    "sku": "SAUCE-BASE-01",
+    "approved_price": { "unit_cost": 0.01, "currency": "RM", "quoted_at": "2025-09-25", "supplier_id": "sup_condiments_a" }
+  }
+]

--- a/assets/data/menu.json
+++ b/assets/data/menu.json
@@ -1,0 +1,14 @@
+{
+  "id": "menu_kebab",
+  "name": "Kyros Kebab",
+  "yield_qty": 1,
+  "yield_unit": "serving",
+  "selling_price": 12.9,
+  "status": "Published",
+  "misc_pct": 0.1,
+  "items": [
+    { "ingredient_id": "ing_pita", "ingredient_name": "Pita Bread", "unit": "pcs", "cost_per_unit": 0.8, "quantity": 1 },
+    { "ingredient_id": "ing_beef", "ingredient_name": "Beef Slice", "unit": "g", "cost_per_unit": 0.035, "quantity": 120 },
+    { "ingredient_id": "ing_sauce_base", "ingredient_name": "Sauce Base", "unit": "ml", "cost_per_unit": 0.01, "quantity": 40 }
+  ]
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,504 @@
+(function () {
+  const { __ } = wp.i18n;
+
+  const state = {
+    isConfigured: Boolean(KyrosFnbConfig?.isConfigured),
+    loading: true,
+    saving: false,
+    menu: null,
+    sha: null,
+    ingredients: [],
+    categories: [],
+  };
+
+  const root = document.getElementById('kyros-fnb-app');
+  if (!root) {
+    return;
+  }
+
+  const currencyFormatter = new Intl.NumberFormat('en-MY', {
+    style: 'currency',
+    currency: 'MYR',
+    minimumFractionDigits: 2,
+  });
+
+  function setLoading(isLoading) {
+    state.loading = isLoading;
+    render();
+  }
+
+  function showError(message) {
+    wp.data.dispatch('core/notices').createNotice('error', message, {
+      isDismissible: true,
+    });
+  }
+
+  async function fetchJson(endpoint) {
+    const response = await fetch(`${KyrosFnbConfig.restUrl}/${endpoint}`, {
+      headers: {
+        'X-WP-Nonce': KyrosFnbConfig.nonce,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || __('Request failed', 'kyros-fnb'));
+    }
+
+    return response.json();
+  }
+
+  async function loadData() {
+    try {
+      setLoading(true);
+      const [menuRes, ingredientsRes, categoriesRes] = await Promise.all([
+        fetchJson('menu'),
+        fetchJson('ingredients'),
+        fetchJson('categories'),
+      ]);
+
+      state.menu = menuRes.menu || {};
+      state.sha = menuRes.sha || null;
+      state.ingredients = ingredientsRes.ingredients || [];
+      state.categories = categoriesRes.categories || [];
+
+      if (!Array.isArray(state.menu.items)) {
+        state.menu.items = [];
+      }
+    } catch (error) {
+      console.error(error);
+      showError(__('Unable to load menu data. Fallback sample data will be used.', 'kyros-fnb'));
+      if (!state.menu) {
+        state.menu = { items: [] };
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function computeTotals() {
+    const items = state.menu.items || [];
+    const subtotal = items.reduce((acc, item) => acc + (Number(item.cost_per_unit) || 0) * (Number(item.quantity) || 0), 0);
+    const miscPct = Number(state.menu.misc_pct) || 0;
+    const misc = subtotal * miscPct;
+    const selling = Number(state.menu.selling_price) || 0;
+    const total = subtotal + misc;
+    const costPercent = selling ? (total / selling) * 100 : 0;
+
+    return { subtotal, misc, total, selling, costPercent };
+  }
+
+  function handleItemChange(index, field, value) {
+    const item = state.menu.items[index];
+    if (!item) {
+      return;
+    }
+
+    if (field === 'ingredient_id') {
+      const ingredient = state.ingredients.find((ing) => ing.id === value);
+      item.ingredient_id = value;
+      item.ingredient_name = ingredient ? ingredient.name : '';
+      if (ingredient?.approved_price?.unit_cost) {
+        item.cost_per_unit = Number(ingredient.approved_price.unit_cost);
+      }
+      item.unit = ingredient?.base_unit || item.unit || '';
+    } else if (field === 'cost_per_unit' || field === 'quantity') {
+      item[field] = Number(value) || 0;
+    } else {
+      item[field] = value;
+    }
+
+    render();
+  }
+
+  function addIngredientRow() {
+    state.menu.items.push({
+      ingredient_id: '',
+      ingredient_name: '',
+      unit: '',
+      cost_per_unit: 0,
+      quantity: 0,
+    });
+    render();
+  }
+
+  function removeIngredientRow(index) {
+    state.menu.items.splice(index, 1);
+    render();
+  }
+
+  function updateMenuField(field, value) {
+    if (field === 'misc_pct') {
+      state.menu.misc_pct = Number(value) || 0;
+    } else if (field === 'selling_price' || field === 'yield_qty') {
+      state.menu[field] = Number(value) || 0;
+    } else {
+      state.menu[field] = value;
+    }
+    render();
+  }
+
+  function exportPdf() {
+    if (!window.jspdf || !window.jspdf.jsPDF) {
+      showError(__('PDF library failed to load. Please refresh and try again.', 'kyros-fnb'));
+      return;
+    }
+
+    const { subtotal, misc, total, selling, costPercent } = computeTotals();
+    const doc = new window.jspdf.jsPDF({ format: 'a4', unit: 'pt' });
+    const margin = 40;
+    const brandColor = '#d91c1c';
+
+    doc.setFillColor(217, 28, 28);
+    doc.rect(0, 0, 595, 70, 'F');
+    doc.setTextColor('#ffffff');
+    doc.setFontSize(20);
+    doc.text('Kyros F&B Cost Calculator', margin, 45);
+
+    doc.setTextColor('#000000');
+    doc.setFontSize(14);
+    doc.text(`Menu: ${state.menu.name || 'Untitled Menu'}`, margin, 100);
+    doc.setFontSize(11);
+    doc.text(`Yield: ${state.menu.yield_qty || 1} ${state.menu.yield_unit || 'serving'}`, margin, 120);
+
+    const rows = (state.menu.items || []).map((item) => [
+      item.ingredient_name || item.ingredient_id || __('New Ingredient', 'kyros-fnb'),
+      item.unit || '-',
+      currencyFormatter.format(Number(item.cost_per_unit) || 0),
+      Number(item.quantity) || 0,
+      currencyFormatter.format((Number(item.cost_per_unit) || 0) * (Number(item.quantity) || 0)),
+    ]);
+
+    doc.autoTable({
+      startY: 140,
+      head: [[__('Item', 'kyros-fnb'), __('Unit', 'kyros-fnb'), __('Cost/Unit', 'kyros-fnb'), __('Quantity', 'kyros-fnb'), __('Total', 'kyros-fnb')]],
+      body: rows,
+      theme: 'striped',
+      styles: { fillColor: [249, 243, 243], textColor: '#000' },
+      headStyles: { fillColor: brandColor, textColor: '#fff' },
+    });
+
+    const summaryY = doc.lastAutoTable.finalY + 20;
+    doc.setFontSize(12);
+    doc.setTextColor(brandColor);
+    doc.text(__('Summary', 'kyros-fnb'), margin, summaryY);
+    doc.setTextColor('#000000');
+    const miscPct = Number(state.menu.misc_pct) || 0;
+    const summaryLines = [
+      `${__('Subtotal', 'kyros-fnb')}: ${currencyFormatter.format(subtotal)}`,
+      `${__('Misc', 'kyros-fnb')} (${(miscPct * 100).toFixed(1)}%): ${currencyFormatter.format(misc)}`,
+      `${__('Total Cost', 'kyros-fnb')}: ${currencyFormatter.format(total)}`,
+      `${__('Selling Price', 'kyros-fnb')}: ${currencyFormatter.format(selling)}`,
+      `${__('Cost %', 'kyros-fnb')}: ${costPercent.toFixed(1)}%`,
+    ];
+
+    summaryLines.forEach((line, index) => {
+      doc.text(line, margin, summaryY + 20 + index * 16);
+    });
+
+    const filename = `fbcalc_menu_${(state.menu.id || 'menu').replace(/[^a-z0-9_-]/gi, '')}_${formatTimestamp()}.pdf`;
+    doc.save(filename);
+  }
+
+  function exportExcel() {
+    if (!window.XLSX) {
+      showError(__('Excel library failed to load. Please refresh and try again.', 'kyros-fnb'));
+      return;
+    }
+
+    const items = (state.menu.items || []).map((item) => ({
+      Item: item.ingredient_name || item.ingredient_id || __('New Ingredient', 'kyros-fnb'),
+      Unit: item.unit || '-',
+      CostPerUnit: Number(item.cost_per_unit) || 0,
+      Quantity: Number(item.quantity) || 0,
+      Total: (Number(item.cost_per_unit) || 0) * (Number(item.quantity) || 0),
+    }));
+
+    const worksheet = window.XLSX.utils.json_to_sheet(items, {
+      header: ['Item', 'Unit', 'CostPerUnit', 'Quantity', 'Total'],
+    });
+
+    const range = window.XLSX.utils.decode_range(worksheet['!ref']);
+    for (let row = range.s.r + 1; row <= range.e.r; row += 1) {
+      const costCell = window.XLSX.utils.encode_cell({ r: row, c: 2 });
+      const qtyCell = window.XLSX.utils.encode_cell({ r: row, c: 3 });
+      const totalCell = window.XLSX.utils.encode_cell({ r: row, c: 4 });
+      worksheet[totalCell] = { f: `${costCell}*${qtyCell}` };
+      worksheet[costCell].z = '[$RM-421]#,##0.00';
+    }
+    worksheet[window.XLSX.utils.encode_cell({ r: range.e.r, c: 4 })].z = '[$RM-421]#,##0.00';
+
+    const workbook = window.XLSX.utils.book_new();
+    window.XLSX.utils.book_append_sheet(workbook, worksheet, 'Menu');
+
+    const summary = computeTotals();
+    const summarySheet = window.XLSX.utils.aoa_to_sheet([
+      ['Metric', 'Value'],
+      ['Subtotal', summary.subtotal],
+      ['Misc', summary.misc],
+      ['Total', summary.total],
+      ['Selling Price', summary.selling],
+      ['Cost %', summary.costPercent],
+    ]);
+
+    const summaryRange = window.XLSX.utils.decode_range(summarySheet['!ref']);
+    for (let row = summaryRange.s.r + 1; row <= summaryRange.e.r; row += 1) {
+      const valueCell = window.XLSX.utils.encode_cell({ r: row, c: 1 });
+      if (row <= summaryRange.s.r + 4) {
+        summarySheet[valueCell].z = '[$RM-421]#,##0.00';
+      } else {
+        summarySheet[valueCell].z = '0.0%';
+      }
+    }
+
+    window.XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary');
+
+    const filename = `fbcalc_menu_${(state.menu.id || 'menu').replace(/[^a-z0-9_-]/gi, '')}_${formatTimestamp()}.xlsx`;
+    window.XLSX.writeFile(workbook, filename);
+  }
+
+  function formatTimestamp() {
+    const now = new Date();
+    const pad = (num) => String(num).padStart(2, '0');
+    return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+  }
+
+  async function saveMenu() {
+    if (!state.isConfigured) {
+      showError(__('GitHub credentials are missing. Please configure them in Settings.', 'kyros-fnb'));
+      return;
+    }
+
+    try {
+      state.saving = true;
+      render();
+      const response = await fetch(`${KyrosFnbConfig.restUrl}/menu`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-WP-Nonce': KyrosFnbConfig.nonce,
+        },
+        body: JSON.stringify({
+          content: state.menu,
+          message: `feat(menu): update ${state.menu.name || 'menu'}`,
+          sha: state.sha,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+
+      const data = await response.json();
+      state.sha = data.content?.sha || data.sha || state.sha;
+      wp.data.dispatch('core/notices').createNotice('success', __('Menu saved to GitHub.', 'kyros-fnb'), {
+        isDismissible: true,
+      });
+    } catch (error) {
+      console.error(error);
+      showError(__('Saving to GitHub failed. Check your credentials and repository permissions.', 'kyros-fnb'));
+    } finally {
+      state.saving = false;
+      render();
+    }
+  }
+
+  function renderSummary() {
+    const { subtotal, misc, total, selling, costPercent } = computeTotals();
+    return `
+      <div class="kyros-fnb-summary">
+        <div class="kyros-fnb-card">
+          <h3>${__('Subtotal', 'kyros-fnb')}</h3>
+          <p>${currencyFormatter.format(subtotal)}</p>
+        </div>
+        <div class="kyros-fnb-card">
+          <h3>${__('Misc', 'kyros-fnb')} (${((Number(state.menu.misc_pct) || 0) * 100).toFixed(1)}%)</h3>
+          <p>${currencyFormatter.format(misc)}</p>
+        </div>
+        <div class="kyros-fnb-card">
+          <h3>${__('Total Cost', 'kyros-fnb')}</h3>
+          <p>${currencyFormatter.format(total)}</p>
+        </div>
+        <div class="kyros-fnb-card">
+          <h3>${__('Selling Price', 'kyros-fnb')}</h3>
+          <p>${currencyFormatter.format(selling)}</p>
+        </div>
+        <div class="kyros-fnb-card">
+          <h3>${__('Cost %', 'kyros-fnb')}</h3>
+          <p>${costPercent.toFixed(1)}%</p>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderToolbar() {
+    return `
+      <div class="kyros-fnb-toolbar">
+        <button type="button" class="button button-primary kyros-fnb-button-primary" data-action="save" ${state.saving || !state.isConfigured ? 'disabled' : ''}>
+          ${state.isConfigured ? (state.saving ? __('Saving…', 'kyros-fnb') : __('Save to GitHub', 'kyros-fnb')) : __('Configure GitHub to Save', 'kyros-fnb')}
+        </button>
+        <button type="button" class="button" data-action="add-row">${__('Add Ingredient', 'kyros-fnb')}</button>
+        <button type="button" class="button" data-action="export-pdf">${__('Export PDF', 'kyros-fnb')}</button>
+        <button type="button" class="button" data-action="export-excel">${__('Export Excel', 'kyros-fnb')}</button>
+      </div>
+    `;
+  }
+
+  function renderTable() {
+    const rows = (state.menu.items || []).map((item, index) => {
+      const ingredientOptions = state.ingredients
+        .map((ingredient) => {
+          const selected = ingredient.id === item.ingredient_id ? 'selected' : '';
+          return `<option value="${ingredient.id}" ${selected}>${ingredient.name}</option>`;
+        })
+        .join('');
+      const total = (Number(item.cost_per_unit) || 0) * (Number(item.quantity) || 0);
+      return `
+        <tr data-index="${index}">
+          <td>
+            <select data-field="ingredient_id">
+              <option value="">${__('Select ingredient', 'kyros-fnb')}</option>
+              ${ingredientOptions}
+            </select>
+          </td>
+          <td><input type="text" data-field="unit" value="${item.unit || ''}" /></td>
+          <td><input type="number" step="0.0001" min="0" data-field="cost_per_unit" value="${Number(item.cost_per_unit) || 0}" /></td>
+          <td><input type="number" step="0.0001" min="0" data-field="quantity" value="${Number(item.quantity) || 0}" /></td>
+          <td>${currencyFormatter.format(total)}</td>
+          <td><button type="button" class="button-link delete" data-field="delete">${__('Remove', 'kyros-fnb')}</button></td>
+        </tr>
+      `;
+    });
+
+    return `
+      <table class="widefat">
+        <thead>
+          <tr>
+            <th>${__('Item', 'kyros-fnb')}</th>
+            <th>${__('Unit', 'kyros-fnb')}</th>
+            <th>${__('Cost/Unit', 'kyros-fnb')}</th>
+            <th>${__('Quantity', 'kyros-fnb')}</th>
+            <th>${__('Total', 'kyros-fnb')}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows.join('')}
+        </tbody>
+      </table>
+    `;
+  }
+
+  function renderMeta() {
+    return `
+      <div class="kyros-fnb-meta">
+        <table class="form-table">
+          <tr>
+            <th><label for="kyros-menu-name">${__('Menu Name', 'kyros-fnb')}</label></th>
+            <td><input type="text" id="kyros-menu-name" data-menu-field="name" value="${state.menu.name || ''}" /></td>
+          </tr>
+          <tr>
+            <th><label for="kyros-menu-yield">${__('Yield Quantity', 'kyros-fnb')}</label></th>
+            <td><input type="number" min="0" step="0.01" id="kyros-menu-yield" data-menu-field="yield_qty" value="${Number(state.menu.yield_qty) || 0}" /></td>
+          </tr>
+          <tr>
+            <th><label for="kyros-menu-unit">${__('Yield Unit', 'kyros-fnb')}</label></th>
+            <td><input type="text" id="kyros-menu-unit" data-menu-field="yield_unit" value="${state.menu.yield_unit || ''}" /></td>
+          </tr>
+          <tr>
+            <th><label for="kyros-menu-selling">${__('Selling Price', 'kyros-fnb')}</label></th>
+            <td><input type="number" min="0" step="0.01" id="kyros-menu-selling" data-menu-field="selling_price" value="${Number(state.menu.selling_price) || 0}" /></td>
+          </tr>
+          <tr>
+            <th><label for="kyros-menu-misc">${__('Misc %', 'kyros-fnb')}</label></th>
+            <td><input type="number" min="0" step="0.01" id="kyros-menu-misc" data-menu-field="misc_pct" value="${Number(state.menu.misc_pct) || 0}" /></td>
+          </tr>
+        </table>
+      </div>
+    `;
+  }
+
+  function renderChartPlaceholder() {
+    return `
+      <div class="kyros-fnb-chart">
+        ${__('Chart placeholder – integrate with Chart.js or Recharts if desired.', 'kyros-fnb')}
+      </div>
+    `;
+  }
+
+  function render() {
+    if (state.loading) {
+      root.innerHTML = `<p>${__('Loading menu data…', 'kyros-fnb')}</p>`;
+      return;
+    }
+
+    root.innerHTML = `
+      ${renderToolbar()}
+      ${renderMeta()}
+      ${renderTable()}
+      ${renderSummary()}
+      ${renderChartPlaceholder()}
+    `;
+  }
+
+  root.addEventListener('change', (event) => {
+    const row = event.target.closest('tr[data-index]');
+    if (row) {
+      const index = Number(row.dataset.index);
+      const field = event.target.dataset.field;
+      if (field) {
+        handleItemChange(index, field, event.target.value);
+      }
+    }
+
+    const menuField = event.target.dataset.menuField;
+    if (menuField) {
+      updateMenuField(menuField, event.target.value);
+    }
+  });
+
+  root.addEventListener('input', (event) => {
+    const row = event.target.closest('tr[data-index]');
+    if (row) {
+      const index = Number(row.dataset.index);
+      const field = event.target.dataset.field;
+      if (field) {
+        handleItemChange(index, field, event.target.value);
+      }
+    }
+
+    const menuField = event.target.dataset.menuField;
+    if (menuField) {
+      updateMenuField(menuField, event.target.value);
+    }
+  });
+
+  root.addEventListener('click', (event) => {
+    const action = event.target.dataset.action;
+    if (action === 'add-row') {
+      addIngredientRow();
+      return;
+    }
+    if (action === 'export-pdf') {
+      exportPdf();
+      return;
+    }
+    if (action === 'export-excel') {
+      exportExcel();
+      return;
+    }
+    if (action === 'save') {
+      saveMenu();
+      return;
+    }
+
+    if (event.target.dataset.field === 'delete') {
+      const row = event.target.closest('tr[data-index]');
+      if (row) {
+        removeIngredientRow(Number(row.dataset.index));
+      }
+    }
+  });
+
+  loadData();
+})();

--- a/includes/class-kyros-fnb-github-client.php
+++ b/includes/class-kyros-fnb-github-client.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * GitHub client helper for Kyros F&B Cost Calculator.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Kyros_FnB_GitHub_Client {
+    private string $token;
+    private string $owner;
+    private string $repo;
+
+    public function __construct( string $token, string $owner, string $repo ) {
+        $this->token = $token;
+        $this->owner = $owner;
+        $this->repo  = $repo;
+    }
+
+    public static function is_configured(): bool {
+        return (bool) get_option( 'kyros_fnb_github_token' ) &&
+            (bool) get_option( 'kyros_fnb_github_owner' ) &&
+            (bool) get_option( 'kyros_fnb_github_repo' );
+    }
+
+    private function api_base(): string {
+        return sprintf( 'https://api.github.com/repos/%s/%s/contents/', rawurlencode( $this->owner ), rawurlencode( $this->repo ) );
+    }
+
+    /**
+     * Perform a request against the GitHub contents API.
+     *
+     * @throws WP_Error on failure.
+     */
+    private function request( string $method, string $path, array $body = [] ) {
+        $url  = trailingslashit( $this->api_base() ) . ltrim( $path, '/' );
+        $args = [
+            'method'  => $method,
+            'headers' => [
+                'Authorization' => 'token ' . $this->token,
+                'Content-Type'  => 'application/json',
+                'Accept'        => 'application/vnd.github+json',
+                'User-Agent'    => 'kyros-fnb-cost-calculator',
+            ],
+        ];
+
+        if ( ! empty( $body ) ) {
+            $args['body'] = wp_json_encode( $body );
+        }
+
+        $response = wp_remote_request( $url, $args );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( $code < 200 || $code >= 300 ) {
+            return new WP_Error( 'kyros_fnb_github_error', __( 'GitHub API request failed.', 'kyros-fnb' ), [
+                'status'   => $code,
+                'response' => wp_remote_retrieve_body( $response ),
+            ] );
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( JSON_ERROR_NONE !== json_last_error() ) {
+            return new WP_Error( 'kyros_fnb_json_error', __( 'Invalid JSON returned from GitHub.', 'kyros-fnb' ) );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Retrieve file contents and metadata from GitHub.
+     */
+    public function get_file( string $path ) {
+        return $this->request( 'GET', $path );
+    }
+
+    /**
+     * Create or update a file on GitHub.
+     */
+    public function put_file( string $path, string $content, string $message, ?string $sha = null ) {
+        $body = [
+            'message' => $message,
+            'content' => base64_encode( $content ),
+        ];
+
+        if ( $sha ) {
+            $body['sha'] = $sha;
+        }
+
+        return $this->request( 'PUT', $path, $body );
+    }
+}

--- a/includes/class-kyros-fnb-plugin.php
+++ b/includes/class-kyros-fnb-plugin.php
@@ -1,0 +1,364 @@
+<?php
+/**
+ * Core plugin bootstrap.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Kyros_FnB_Cost_Calculator {
+    private static ?Kyros_FnB_Cost_Calculator $instance = null;
+
+    private function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+    }
+
+    public static function instance(): Kyros_FnB_Cost_Calculator {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function register_admin_menu(): void {
+        add_menu_page(
+            __( 'Kyros F&B', 'kyros-fnb' ),
+            __( 'Kyros F&B', 'kyros-fnb' ),
+            'manage_options',
+            'kyros-fnb-cost-calculator',
+            [ $this, 'render_calculator_page' ],
+            'dashicons-analytics',
+            58
+        );
+
+        add_submenu_page(
+            'options-general.php',
+            __( 'Kyros F&B Cost Calculator', 'kyros-fnb' ),
+            __( 'Kyros F&B Cost Calculator', 'kyros-fnb' ),
+            'manage_options',
+            'kyros-fnb-settings',
+            [ $this, 'render_settings_page' ]
+        );
+    }
+
+    public function register_settings(): void {
+        register_setting( 'kyros_fnb_settings', 'kyros_fnb_github_owner' );
+        register_setting( 'kyros_fnb_settings', 'kyros_fnb_github_repo' );
+        register_setting( 'kyros_fnb_settings', 'kyros_fnb_github_token' );
+        register_setting( 'kyros_fnb_settings', 'kyros_fnb_menu_path' );
+        register_setting( 'kyros_fnb_settings', 'kyros_fnb_ingredients_path' );
+        register_setting( 'kyros_fnb_settings', 'kyros_fnb_categories_path' );
+
+        add_settings_section(
+            'kyros_fnb_settings_section',
+            __( 'GitHub Repository Settings', 'kyros-fnb' ),
+            function () {
+                echo '<p>' . esc_html__( 'Provide the repository details where menu, ingredient, and category files are stored.', 'kyros-fnb' ) . '</p>';
+            },
+            'kyros-fnb-settings'
+        );
+
+        $fields = [
+            'kyros_fnb_github_owner'      => __( 'GitHub Owner/Organisation', 'kyros-fnb' ),
+            'kyros_fnb_github_repo'       => __( 'GitHub Repository', 'kyros-fnb' ),
+            'kyros_fnb_github_token'      => __( 'GitHub Personal Access Token', 'kyros-fnb' ),
+            'kyros_fnb_menu_path'         => __( 'Default Menu Path', 'kyros-fnb' ),
+            'kyros_fnb_ingredients_path'  => __( 'Ingredients Path', 'kyros-fnb' ),
+            'kyros_fnb_categories_path'   => __( 'Categories Path', 'kyros-fnb' ),
+        ];
+
+        foreach ( $fields as $option => $label ) {
+            add_settings_field(
+                $option,
+                $label,
+                function () use ( $option ) {
+                    $value       = esc_attr( get_option( $option, '' ) );
+                    $type        = 'kyros_fnb_github_token' === $option ? 'password' : 'text';
+                    $placeholder = '';
+                    switch ( $option ) {
+                        case 'kyros_fnb_menu_path':
+                            $placeholder = 'menus/kebab.json';
+                            break;
+                        case 'kyros_fnb_ingredients_path':
+                            $placeholder = 'data/ingredients.json';
+                            break;
+                        case 'kyros_fnb_categories_path':
+                            $placeholder = 'data/categories.json';
+                            break;
+                    }
+                    printf(
+                        '<input type="%1$s" class="regular-text" name="%2$s" id="%2$s" value="%3$s" placeholder="%4$s" autocomplete="off" />',
+                        esc_attr( $type ),
+                        esc_attr( $option ),
+                        $value,
+                        esc_attr( $placeholder )
+                    );
+                },
+                'kyros-fnb-settings',
+                'kyros_fnb_settings_section'
+            );
+        }
+    }
+
+    public function render_settings_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Kyros F&B Cost Calculator Settings', 'kyros-fnb' ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( 'kyros_fnb_settings' );
+                do_settings_sections( 'kyros-fnb-settings' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function render_calculator_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        ?>
+        <div class="wrap kyros-fnb-admin">
+            <h1><?php esc_html_e( 'Kyros F&B Cost Calculator', 'kyros-fnb' ); ?></h1>
+            <p class="description">
+                <?php esc_html_e( 'Load menu data from GitHub, adjust ingredient costs, and export Kyros-branded PDF or Excel reports.', 'kyros-fnb' ); ?>
+            </p>
+            <div id="kyros-fnb-app" class="kyros-fnb-app" data-menu-path="<?php echo esc_attr( get_option( 'kyros_fnb_menu_path', 'menus/kebab.json' ) ); ?>"></div>
+        </div>
+        <?php
+    }
+
+    public function enqueue_assets( string $hook ): void {
+        if ( 'toplevel_page_kyros-fnb-cost-calculator' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'kyros-fnb-admin',
+            KYROS_FNB_PLUGIN_URL . 'assets/css/admin.css',
+            [],
+            '1.0.0'
+        );
+
+        wp_register_script( 'kyros-fnb-jspdf', 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js', [], '2.5.1', true );
+        wp_register_script( 'kyros-fnb-autotable', 'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.2/dist/jspdf.plugin.autotable.min.js', [ 'kyros-fnb-jspdf' ], '3.8.2', true );
+        wp_register_script( 'kyros-fnb-sheetjs', 'https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js', [], '0.18.5', true );
+
+        wp_register_script(
+            'kyros-fnb-admin',
+            KYROS_FNB_PLUGIN_URL . 'assets/js/admin.js',
+            [ 'wp-i18n', 'wp-element', 'wp-data', 'kyros-fnb-jspdf', 'kyros-fnb-autotable', 'kyros-fnb-sheetjs' ],
+            '1.0.0',
+            true
+        );
+
+        wp_localize_script(
+            'kyros-fnb-admin',
+            'KyrosFnbConfig',
+            [
+                'restUrl'        => esc_url_raw( rest_url( 'kyros-fnb/v1' ) ),
+                'nonce'          => wp_create_nonce( 'wp_rest' ),
+                'menuPath'       => get_option( 'kyros_fnb_menu_path', 'menus/kebab.json' ),
+                'ingredientsPath'=> get_option( 'kyros_fnb_ingredients_path', 'data/ingredients.json' ),
+                'categoriesPath' => get_option( 'kyros_fnb_categories_path', 'data/categories.json' ),
+                'isConfigured'   => Kyros_FnB_GitHub_Client::is_configured(),
+            ]
+        );
+
+        wp_enqueue_script( 'kyros-fnb-admin' );
+    }
+
+    public function register_rest_routes(): void {
+        register_rest_route(
+            'kyros-fnb/v1',
+            '/menu',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'rest_get_menu' ],
+                'permission_callback' => [ $this, 'ensure_capability' ],
+            ]
+        );
+
+        register_rest_route(
+            'kyros-fnb/v1',
+            '/menu',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'rest_save_menu' ],
+                'permission_callback' => [ $this, 'ensure_capability' ],
+                'args'                => [
+                    'content' => [
+                        'required' => true,
+                    ],
+                    'message' => [
+                        'required' => true,
+                    ],
+                    'sha'     => [
+                        'required' => false,
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            'kyros-fnb/v1',
+            '/ingredients',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'rest_get_ingredients' ],
+                'permission_callback' => [ $this, 'ensure_capability' ],
+            ]
+        );
+
+        register_rest_route(
+            'kyros-fnb/v1',
+            '/categories',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'rest_get_categories' ],
+                'permission_callback' => [ $this, 'ensure_capability' ],
+            ]
+        );
+    }
+
+    public function ensure_capability(): bool {
+        return current_user_can( 'manage_options' );
+    }
+
+    private function get_github_client(): Kyros_FnB_GitHub_Client|WP_Error {
+        $token = get_option( 'kyros_fnb_github_token' );
+        $owner = get_option( 'kyros_fnb_github_owner' );
+        $repo  = get_option( 'kyros_fnb_github_repo' );
+
+        if ( empty( $token ) || empty( $owner ) || empty( $repo ) ) {
+            return new WP_Error( 'kyros_fnb_not_configured', __( 'GitHub credentials are not configured.', 'kyros-fnb' ) );
+        }
+
+        return new Kyros_FnB_GitHub_Client( $token, $owner, $repo );
+    }
+
+    private function load_local_data( string $file ): array {
+        $path = KYROS_FNB_PLUGIN_PATH . 'assets/data/' . $file;
+        if ( ! file_exists( $path ) ) {
+            return [];
+        }
+
+        $raw = file_get_contents( $path );
+        if ( ! $raw ) {
+            return [];
+        }
+
+        $data = json_decode( $raw, true );
+        return JSON_ERROR_NONE === json_last_error() ? $data : [];
+    }
+
+    public function rest_get_menu(): WP_REST_Response {
+        $path = get_option( 'kyros_fnb_menu_path', 'menus/kebab.json' );
+        $sha  = null;
+        $data = null;
+
+        $client = $this->get_github_client();
+        if ( ! is_wp_error( $client ) ) {
+            $response = $client->get_file( $path );
+            if ( ! is_wp_error( $response ) && isset( $response['content'] ) ) {
+                $decoded = base64_decode( $response['content'] );
+                if ( false !== $decoded ) {
+                    $data = json_decode( $decoded, true );
+                    if ( JSON_ERROR_NONE === json_last_error() ) {
+                        $sha = $response['sha'] ?? null;
+                    }
+                }
+            }
+        }
+
+        if ( null === $data ) {
+            $data = $this->load_local_data( 'menu.json' );
+        }
+
+        return new WP_REST_Response(
+            [
+                'menu' => $data,
+                'sha'  => $sha,
+            ]
+        );
+    }
+
+    public function rest_save_menu( WP_REST_Request $request ) {
+        $client = $this->get_github_client();
+        if ( is_wp_error( $client ) ) {
+            return $client;
+        }
+
+        $content = $request->get_param( 'content' );
+        $message = $request->get_param( 'message' );
+        $sha     = $request->get_param( 'sha' );
+        $path    = get_option( 'kyros_fnb_menu_path', 'menus/kebab.json' );
+
+        $encoded = wp_json_encode( $content, JSON_PRETTY_PRINT );
+        if ( false === $encoded ) {
+            return new WP_Error( 'kyros_fnb_encode_error', __( 'Unable to encode menu content as JSON.', 'kyros-fnb' ) );
+        }
+
+        $result = $client->put_file( $path, $encoded, $message, $sha ? (string) $sha : null );
+
+        if ( is_wp_error( $result ) ) {
+            return $result;
+        }
+
+        return new WP_REST_Response( $result );
+    }
+
+    public function rest_get_ingredients(): WP_REST_Response {
+        $path = get_option( 'kyros_fnb_ingredients_path', 'data/ingredients.json' );
+        $data = null;
+
+        $client = $this->get_github_client();
+        if ( ! is_wp_error( $client ) ) {
+            $response = $client->get_file( $path );
+            if ( ! is_wp_error( $response ) && isset( $response['content'] ) ) {
+                $decoded = base64_decode( $response['content'] );
+                if ( false !== $decoded ) {
+                    $data = json_decode( $decoded, true );
+                }
+            }
+        }
+
+        if ( null === $data ) {
+            $data = $this->load_local_data( 'ingredients.json' );
+        }
+
+        return new WP_REST_Response( [ 'ingredients' => $data ] );
+    }
+
+    public function rest_get_categories(): WP_REST_Response {
+        $path = get_option( 'kyros_fnb_categories_path', 'data/categories.json' );
+        $data = null;
+
+        $client = $this->get_github_client();
+        if ( ! is_wp_error( $client ) ) {
+            $response = $client->get_file( $path );
+            if ( ! is_wp_error( $response ) && isset( $response['content'] ) ) {
+                $decoded = base64_decode( $response['content'] );
+                if ( false !== $decoded ) {
+                    $data = json_decode( $decoded, true );
+                }
+            }
+        }
+
+        if ( null === $data ) {
+            $data = $this->load_local_data( 'categories.json' );
+        }
+
+        return new WP_REST_Response( [ 'categories' => $data ] );
+    }
+}

--- a/kyros-fnb-cost-calculator.php
+++ b/kyros-fnb-cost-calculator.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Kyros F&B Cost Calculator
+ * Plugin URI: https://kyros.com
+ * Description: WordPress admin experience for the Kyros F&B cost calculator backed by GitHub content and featuring PDF/Excel exports.
+ * Version: 1.0.0
+ * Author: Kyros Digital
+ * License: MIT
+ * License URI: https://opensource.org/licenses/MIT
+ * Text Domain: kyros-fnb
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'KYROS_FNB_PLUGIN_FILE', __FILE__ );
+define( 'KYROS_FNB_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'KYROS_FNB_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+require_once KYROS_FNB_PLUGIN_PATH . 'includes/class-kyros-fnb-github-client.php';
+require_once KYROS_FNB_PLUGIN_PATH . 'includes/class-kyros-fnb-plugin.php';
+
+Kyros_FnB_Cost_Calculator::instance();


### PR DESCRIPTION
## Summary
- replace the previous Next.js app with a WordPress plugin skeleton for the Kyros F&B cost calculator
- add GitHub-backed REST proxy endpoints, admin settings, and a calculator screen with PDF/Excel exports
- bundle Kyros-branded styles and sample menu/ingredient fixtures to allow immediate plugin packaging

## Testing
- php -l kyros-fnb-cost-calculator.php
- php -l includes/class-kyros-fnb-github-client.php
- php -l includes/class-kyros-fnb-plugin.php

------
https://chatgpt.com/codex/tasks/task_b_68dcabb35340832081baca324bb1ec54